### PR TITLE
csb/65: Generalized user home directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "3306:3306"
     volumes:
       - ./mariadb_data:/var/lib/mysql
-      - /home/zli/Desktop/106-exercises/:/workspace
+      - /home/user/Desktop/106-exercises/:/workspace
 
   phpmyadmin:
     container_name: phpmyadmin

--- a/system/shortcuts/Documentation.desktop
+++ b/system/shortcuts/Documentation.desktop
@@ -3,5 +3,5 @@ Version=1.0
 Type=Link
 Name=MariaDB Documentation
 Comment=
-Icon=/home/zli/Pictures/icons/mariadb.svg
+Icon=/home/user/Pictures/icons/mariadb.svg
 URL=https://mariadb.com/kb/en/documentation/

--- a/system/shortcuts/Moodle.desktop
+++ b/system/shortcuts/Moodle.desktop
@@ -3,5 +3,5 @@ Version=1.0
 Type=Link
 Name=Moodle
 Comment=
-Icon=/home/zli/Pictures/icons/moodle.svg
+Icon=/home/user/Pictures/icons/moodle.svg
 URL=https://moodle.zli.ch/login/index.php

--- a/system/shortcuts/phpMyAdmin.desktop
+++ b/system/shortcuts/phpMyAdmin.desktop
@@ -3,5 +3,5 @@ Version=1.0
 Type=Link
 Name=phpMyAdmin
 Comment=
-Icon=/home/zli/Pictures/icons/phpMyAdmin.svg
+Icon=/home/user/Pictures/icons/phpMyAdmin.svg
 URL=http://localhost:8080


### PR DESCRIPTION
We must have general access to the user's home directory to customize the user. `/home/user` is a link that is created by the cloud-init and points to the custom user's home directory.